### PR TITLE
Fix four known bugs: smart collection tags, roster names, stage thumbnails, registration UX

### DIFF
--- a/IKEMEN Lab Tests/SmartCollectionEvaluatorTests.swift
+++ b/IKEMEN Lab Tests/SmartCollectionEvaluatorTests.swift
@@ -358,4 +358,32 @@ final class SmartCollectionEvaluatorTests: XCTestCase {
         XCTAssertEqual(result.characters.count, 0)
         XCTAssertEqual(result.stages.count, 0)
     }
+
+    // MARK: - Tag Normalization Tests
+
+    func testNormalizeTagLowercasesAndTrimsWhitespace() {
+        XCTAssertEqual(SmartCollectionEvaluator.normalizeTag(" HD "), "hd")
+        XCTAssertEqual(SmartCollectionEvaluator.normalizeTag("HD"), "hd")
+        XCTAssertEqual(SmartCollectionEvaluator.normalizeTag("Street Fighter"), "street fighter")
+    }
+
+    func testNormalizeTagStripsNewlines() {
+        // `.whitespaces` would leave \n/\r in place; `.whitespacesAndNewlines` removes them.
+        XCTAssertEqual(SmartCollectionEvaluator.normalizeTag("\nHD\n"), "hd")
+        XCTAssertEqual(SmartCollectionEvaluator.normalizeTag("\tHD\r\n"), "hd")
+    }
+
+    func testNormalizeTagReturnsNilForBlankInput() {
+        XCTAssertNil(SmartCollectionEvaluator.normalizeTag(""))
+        XCTAssertNil(SmartCollectionEvaluator.normalizeTag("   "))
+        XCTAssertNil(SmartCollectionEvaluator.normalizeTag("\n\t  \r"))
+    }
+
+    func testNormalizeTagDeduplicatesAcrossCaseAndWhitespace() {
+        // The evaluator builds `Set(tags.compactMap(normalizeTag))`; verify the
+        // canonical form collapses superficial differences.
+        let raw = ["HD", " hd ", "\nHD\n", "Hd"]
+        let normalized = Set(raw.compactMap(SmartCollectionEvaluator.normalizeTag))
+        XCTAssertEqual(normalized, ["hd"])
+    }
 }

--- a/IKEMEN Lab/Core/SmartCollectionEvaluator.swift
+++ b/IKEMEN Lab/Core/SmartCollectionEvaluator.swift
@@ -104,9 +104,7 @@ class SmartCollectionEvaluator {
             // Storing the canonical lowercase form keeps matching consistent
             // end-to-end — `evaluateTagField` only needs to lowercase the rule input.
             let normalizedTags = Set(
-                (inferredTags + customTags).map {
-                    $0.trimmingCharacters(in: .whitespaces).lowercased()
-                }
+                (inferredTags + customTags).compactMap(Self.normalizeTag)
             )
             let allTags = normalizedTags.joined(separator: ",")
             return evaluateTagField(allTags, rule: rule)
@@ -182,14 +180,19 @@ class SmartCollectionEvaluator {
         }
     }
     
+    /// Canonicalize a tag: trim whitespace and newlines, lowercase, and
+    /// drop empties. Returns nil so callers can `compactMap` and skip blanks.
+    static func normalizeTag(_ tag: String) -> String? {
+        let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Evaluate a tag field (comma-separated tags)
     private func evaluateTagField(_ tagsString: String?, rule: FilterRule) -> Bool {
-        let characterTags = tagsString?.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() } ?? []
-        
+        let characterTags = tagsString?.components(separatedBy: ",").compactMap(Self.normalizeTag) ?? []
+
         // The rule value can be a single tag or comma-separated list of tags to search for
-        let searchTags = rule.value.components(separatedBy: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
-            .filter { !$0.isEmpty }
+        let searchTags = rule.value.components(separatedBy: ",").compactMap(Self.normalizeTag)
         
         // Empty search tags = no match
         guard !searchTags.isEmpty else {

--- a/IKEMEN Lab/Core/SmartCollectionEvaluator.swift
+++ b/IKEMEN Lab/Core/SmartCollectionEvaluator.swift
@@ -99,13 +99,16 @@ class SmartCollectionEvaluator {
                 author: character.author
             )
             let customTags = (try? metadataStore.customTags(for: character.id)) ?? []
-            
-            // Combine all tags, removing duplicates
-            var allTagsSet = Set<String>()
-            for tag in inferredTags + customTags {
-                allTagsSet.insert(tag.lowercased())
-            }
-            let allTags = allTagsSet.joined(separator: ",")
+
+            // Normalize all tags to lowercase, trimmed, deduplicated.
+            // Storing the canonical lowercase form keeps matching consistent
+            // end-to-end — `evaluateTagField` only needs to lowercase the rule input.
+            let normalizedTags = Set(
+                (inferredTags + customTags).map {
+                    $0.trimmingCharacters(in: .whitespaces).lowercased()
+                }
+            )
+            let allTags = normalizedTags.joined(separator: ",")
             return evaluateTagField(allTags, rule: rule)
         case .installedAt:
             return evaluateDateField(character.installedAt, rule: rule)

--- a/IKEMEN Lab/UI/CharacterBrowserView.swift
+++ b/IKEMEN Lab/UI/CharacterBrowserView.swift
@@ -194,6 +194,13 @@ class CharacterBrowserView: NSView {
             forSupplementaryViewOfKind: NSCollectionView.elementKindSectionHeader,
             withIdentifier: NSUserInterfaceItemIdentifier("CutoffDivider")
         )
+
+        // Register supplementary view for the registered/unregistered split.
+        collectionView.register(
+            RegistrationDividerView.self,
+            forSupplementaryViewOfKind: NSCollectionView.elementKindSectionHeader,
+            withIdentifier: NSUserInterfaceItemIdentifier("RegistrationDivider")
+        )
         
         // Set up context menu provider
         collectionView.menuProvider = { [weak self] indexPath in
@@ -334,13 +341,43 @@ NotificationCenter.default.publisher(for: .customTagsChanged)
     private func applyFilters() {
         switch registrationFilter {
         case .all:
-            characters = allCharacters
+            // Group registered (active/disabled) before unregistered while
+            // preserving relative ordering inside each group. The section
+            // header in section 1 visually labels the unregistered group.
+            characters = allCharacters.sorted { lhs, rhs in
+                let lUnreg = (lhs.status == .unregistered)
+                let rUnreg = (rhs.status == .unregistered)
+                if lUnreg == rUnreg { return false }  // stable within group
+                return !lUnreg  // registered first
+            }
         case .registeredOnly:
             characters = allCharacters.filter { $0.status == .active || $0.status == .disabled }
         case .unregisteredOnly:
             characters = allCharacters.filter { $0.status == .unregistered }
         }
         scheduleReload()
+    }
+
+    // MARK: - Registration Section Grouping
+
+    /// Index of the first unregistered character in `characters`, if any
+    /// (and only when we should show the unregistered section divider).
+    private func unregisteredSectionStartIndex() -> Int? {
+        // Cutoff divider takes priority: it already uses sections, mixing
+        // the two would require more invasive layout changes.
+        if shouldShowCutoffDivider() { return nil }
+        // Only meaningful when the user is viewing all characters.
+        guard registrationFilter == .all else { return nil }
+        guard let firstUnreg = characters.firstIndex(where: { $0.status == .unregistered }) else {
+            return nil
+        }
+        // Only show the divider if there is at least one registered above it.
+        return firstUnreg > 0 ? firstUnreg : nil
+    }
+
+    /// Whether the registered/unregistered section divider should be shown.
+    private func shouldShowRegistrationDivider() -> Bool {
+        return unregisteredSectionStartIndex() != nil
     }
     
     /// Coalesce rapid successive reloads into a single reload
@@ -386,13 +423,7 @@ NotificationCenter.default.publisher(for: .customTagsChanged)
                     // Find and update the item in the correct section
                     guard let self else { return }
                     if let index = self.characters.firstIndex(where: { $0.id == character.id }) {
-                        let indexPath: IndexPath
-                        if self.shouldShowCutoffDivider() && index >= self.activeScreenpackSlotLimit {
-                            indexPath = IndexPath(item: index - self.activeScreenpackSlotLimit, section: 1)
-                        } else {
-                            indexPath = IndexPath(item: index, section: 0)
-                        }
-                        
+                        let indexPath = self.indexPath(forCharacterAt: index)
                         if let item = self.collectionView.item(at: indexPath) as? CharacterCollectionViewItem {
                             item.setPortrait(self.portraitCache[character.id])
                         }
@@ -941,18 +972,9 @@ NotificationCenter.default.publisher(for: .customTagsChanged)
     /// Show context menu from the more button in list view
     private func showContextMenuForListItem(_ character: CharacterInfo, sourceView: NSView) {
         guard let index = characters.firstIndex(where: { $0.id == character.id }) else { return }
-        
+
         // Determine the correct section and item index
-        let indexPath: IndexPath
-        if shouldShowCutoffDivider() {
-            if index < activeScreenpackSlotLimit {
-                indexPath = IndexPath(item: index, section: 0)
-            } else {
-                indexPath = IndexPath(item: index - activeScreenpackSlotLimit, section: 1)
-            }
-        } else {
-            indexPath = IndexPath(item: index, section: 0)
-        }
+        let indexPath = self.indexPath(forCharacterAt: index)
 
         if !collectionView.selectionIndexPaths.contains(indexPath) {
             collectionView.selectItems(at: [indexPath], scrollPosition: [])
@@ -972,13 +994,15 @@ NotificationCenter.default.publisher(for: .customTagsChanged)
 extension CharacterBrowserView: NSCollectionViewDataSource {
     
     func numberOfSections(in collectionView: NSCollectionView) -> Int {
-        // Use 2 sections if there's a cutoff, otherwise 1
-        if shouldShowCutoffDivider() {
-            return 2  // Section 0: visible characters, Section 1: hidden characters
+        // Use 2 sections if there's a cutoff or registration split, otherwise 1.
+        // Cutoff and registration are mutually exclusive: when slot-cutoff
+        // applies it takes priority (see unregisteredSectionStartIndex()).
+        if shouldShowCutoffDivider() || shouldShowRegistrationDivider() {
+            return 2
         }
         return 1
     }
-    
+
     func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
         if shouldShowCutoffDivider() {
             // Section 0: visible characters (up to slot limit)
@@ -989,9 +1013,18 @@ extension CharacterBrowserView: NSCollectionViewDataSource {
                 return max(0, characters.count - activeScreenpackSlotLimit)
             }
         }
+        if let split = unregisteredSectionStartIndex() {
+            // Section 0: registered (active/disabled) characters
+            // Section 1: unregistered characters
+            if section == 0 {
+                return split
+            } else {
+                return max(0, characters.count - split)
+            }
+        }
         return characters.count
     }
-    
+
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
         // Calculate actual character index based on section
         let characterIndex: Int
@@ -1001,68 +1034,93 @@ extension CharacterBrowserView: NSCollectionViewDataSource {
             } else {
                 characterIndex = activeScreenpackSlotLimit + indexPath.item
             }
+        } else if let split = unregisteredSectionStartIndex() {
+            if indexPath.section == 0 {
+                characterIndex = indexPath.item
+            } else {
+                characterIndex = split + indexPath.item
+            }
         } else {
             characterIndex = indexPath.item
         }
-        
+
         let character = characters[characterIndex]
         let isDuplicate = duplicateIds.contains(character.id)
-        
+        let isInUnregisteredSection = (shouldShowCutoffDivider() && indexPath.section == 1)
+            || (unregisteredSectionStartIndex() != nil && indexPath.section == 1)
+
         if viewMode == .grid {
             let item = collectionView.makeItem(withIdentifier: CharacterCollectionViewItem.identifier, for: indexPath) as! CharacterCollectionViewItem
             let tags = mergedTags(for: character)
             item.configure(with: character, tags: tags, isDuplicate: isDuplicate)
-            
+
             if let cachedPortrait = portraitCache[character.id] {
                 item.setPortrait(cachedPortrait)
             }
-            
-            // Dim characters in section 1 (hidden) but keep interactions intact
-            item.view.alphaValue = shouldShowCutoffDivider() && indexPath.section == 1 ? 0.5 : 1.0
-            
+
+            // Dim characters in the secondary section (hidden or unregistered).
+            item.view.alphaValue = isInUnregisteredSection ? 0.6 : 1.0
+
             return item
         } else {
             let item = collectionView.makeItem(withIdentifier: CharacterListItem.identifier, for: indexPath) as! CharacterListItem
             item.configure(with: character, isDuplicate: isDuplicate)
-            
+
             // Wire up the toggle callback
             item.onStatusToggled = { [weak self] isEnabled in
                 // Toggle means we're changing the state - if toggled ON, we want to enable
                 self?.onCharacterDisableToggle?(character)
             }
-            
+
             // Wire up the more button callback
             item.onMoreClicked = { [weak self] char, sourceView in
                 self?.showContextMenuForListItem(char, sourceView: sourceView)
             }
-            
+
             if let cachedPortrait = portraitCache[character.id] {
                 item.setPortrait(cachedPortrait)
             }
-            
-            // Dim list rows in the hidden section while leaving them fully interactive
-            item.view.alphaValue = shouldShowCutoffDivider() && indexPath.section == 1 ? 0.5 : 1.0
-            
+
+            // Dim list rows in the secondary section while leaving them fully interactive.
+            item.view.alphaValue = isInUnregisteredSection ? 0.6 : 1.0
+
             return item
         }
     }
-    
+
     func collectionView(_ collectionView: NSCollectionView, viewForSupplementaryElementOfKind kind: NSCollectionView.SupplementaryElementKind, at indexPath: IndexPath) -> NSView {
-        // Only show header for section 1 (hidden characters)
-        if kind == NSCollectionView.elementKindSectionHeader && indexPath.section == 1 {
+        guard kind == NSCollectionView.elementKindSectionHeader, indexPath.section == 1 else {
+            return NSView()
+        }
+
+        if shouldShowCutoffDivider() {
             let view = collectionView.makeSupplementaryView(
                 ofKind: kind,
                 withIdentifier: NSUserInterfaceItemIdentifier("CutoffDivider"),
                 for: indexPath
             ) as! CutoffDividerView
-            
+
             let visibleCount = min(characters.count, activeScreenpackSlotLimit)
             let hiddenCount = max(0, characters.count - activeScreenpackSlotLimit)
             view.configure(visibleCount: visibleCount, hiddenCount: hiddenCount)
-            
+
             return view
         }
-        
+
+        if let split = unregisteredSectionStartIndex() {
+            let view = collectionView.makeSupplementaryView(
+                ofKind: kind,
+                withIdentifier: NSUserInterfaceItemIdentifier("RegistrationDivider"),
+                for: indexPath
+            ) as! RegistrationDividerView
+
+            let registeredCount = split
+            let unregisteredCount = max(0, characters.count - split)
+            view.configure(registeredCount: registeredCount, unregisteredCount: unregisteredCount)
+
+            return view
+        }
+
         return NSView()
     }
     
@@ -1083,10 +1141,34 @@ extension CharacterBrowserView: NSCollectionViewDataSource {
             } else {
                 index = activeScreenpackSlotLimit + indexPath.item
             }
+        } else if let split = unregisteredSectionStartIndex() {
+            if indexPath.section == 0 {
+                index = indexPath.item
+            } else {
+                index = split + indexPath.item
+            }
         } else {
             index = indexPath.item
         }
         return index < characters.count ? index : nil
+    }
+
+    /// Map a flat character index back into a section/item IndexPath, taking
+    /// the cutoff and registration dividers into account.
+    private func indexPath(forCharacterAt index: Int) -> IndexPath {
+        if shouldShowCutoffDivider() {
+            if index < activeScreenpackSlotLimit {
+                return IndexPath(item: index, section: 0)
+            }
+            return IndexPath(item: index - activeScreenpackSlotLimit, section: 1)
+        }
+        if let split = unregisteredSectionStartIndex() {
+            if index < split {
+                return IndexPath(item: index, section: 0)
+            }
+            return IndexPath(item: index - split, section: 1)
+        }
+        return IndexPath(item: index, section: 0)
     }
 
     private func selectedCharacters() -> [CharacterInfo] {
@@ -1177,44 +1259,28 @@ extension CharacterBrowserView: NSCollectionViewDelegate {
             } else {
                 destinationIndex = activeScreenpackSlotLimit + indexPath.item
             }
+        } else if let split = unregisteredSectionStartIndex() {
+            if indexPath.section == 0 {
+                destinationIndex = indexPath.item
+            } else {
+                destinationIndex = split + indexPath.item
+            }
         } else {
             destinationIndex = indexPath.item
         }
-        
+
         // Adjust destination if moving down
         if sourceIndex < destinationIndex {
             destinationIndex -= 1
         }
-        
+
         // Don't do anything if not actually moving
         guard sourceIndex != destinationIndex else { return false }
-        
+
         // Perform the move in our data model
         let movedCharacter = characters.remove(at: sourceIndex)
         characters.insert(movedCharacter, at: destinationIndex)
-        
-        // Calculate source and destination IndexPaths for animation
-        let sourceIndexPath: IndexPath
-        let destIndexPath: IndexPath
-        
-        if shouldShowCutoffDivider() {
-            // Calculate section-based index paths
-            if sourceIndex < activeScreenpackSlotLimit {
-                sourceIndexPath = IndexPath(item: sourceIndex, section: 0)
-            } else {
-                sourceIndexPath = IndexPath(item: sourceIndex - activeScreenpackSlotLimit, section: 1)
-            }
-            
-            if destinationIndex < activeScreenpackSlotLimit {
-                destIndexPath = IndexPath(item: destinationIndex, section: 0)
-            } else {
-                destIndexPath = IndexPath(item: destinationIndex - activeScreenpackSlotLimit, section: 1)
-            }
-        } else {
-            sourceIndexPath = IndexPath(item: sourceIndex, section: 0)
-            destIndexPath = IndexPath(item: destinationIndex, section: 0)
-        }
-        
+
         // Reload data instead of animating move (safer with sections)
         collectionView.reloadData()
         
@@ -1246,9 +1312,14 @@ extension CharacterBrowserView: NSCollectionViewDelegate {
 extension CharacterBrowserView: NSCollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> NSSize {
-        // Only show header for section 1 (hidden characters section)
-        if section == 1 && shouldShowCutoffDivider() {
+        // Show header for section 1 when either the cutoff or registration
+        // section divider is active.
+        guard section == 1 else { return .zero }
+        if shouldShowCutoffDivider() {
             return NSSize(width: collectionView.bounds.width, height: 40)
+        }
+        if shouldShowRegistrationDivider() {
+            return NSSize(width: collectionView.bounds.width, height: 36)
         }
         return .zero
     }
@@ -1655,10 +1726,13 @@ class CharacterCollectionViewItem: NSCollectionViewItem {
         // Show status dot if this is the first character (placeholder logic - could be enhanced)
         statusDot.isHidden = true
         
-        // Show unregistered overlay and badge for unregistered characters
+        // Registered vs unregistered is now communicated via section grouping
+        // (see CharacterBrowserView). Keep the existing overlay/badge views for
+        // backward compatibility but never show them — the section header and
+        // sort order convey the same information without per-card chrome.
         let isUnregistered = (character.status == .unregistered)
-        unregisteredOverlay.isHidden = !isUnregistered
-        unregisteredBadge.isHidden = !isUnregistered
+        unregisteredOverlay.isHidden = true
+        unregisteredBadge.isHidden = true
         
         // Show duplicate badge
         duplicateBadge.isHidden = !isDuplicate
@@ -2537,5 +2611,93 @@ class CutoffDividerView: NSView, NSCollectionViewElement {
     override func prepareForReuse() {
         visibleCountLabel.stringValue = ""
         hiddenCountLabel.stringValue = ""
+    }
+}
+
+// MARK: - RegistrationDividerView
+
+/// A supplementary view that labels the boundary between registered (in
+/// select.def) and unregistered characters in the browser.
+///
+/// Note: this divider replaces the per-card "UNREGISTERED" badge overlay.
+/// The cutoff (slot-limit) divider takes priority — they are mutually
+/// exclusive in the data source.
+class RegistrationDividerView: NSView, NSCollectionViewElement {
+
+    private var containerView: NSView!
+    private var topLine: NSView!
+    private var titleLabel: NSTextField!
+    private var countLabel: NSTextField!
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        wantsLayer = true
+        layer?.backgroundColor = DesignColors.panelBackground.cgColor
+
+        containerView = NSView()
+        containerView.wantsLayer = true
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(containerView)
+
+        topLine = NSView()
+        topLine.wantsLayer = true
+        topLine.layer?.backgroundColor = DesignColors.borderSubtle.cgColor
+        topLine.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(topLine)
+
+        titleLabel = NSTextField(labelWithString: "Available")
+        titleLabel.font = DesignFonts.caption(size: 11)
+        titleLabel.textColor = DesignColors.textSecondary
+        titleLabel.alignment = .left
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(titleLabel)
+
+        countLabel = NSTextField(labelWithString: "")
+        countLabel.font = DesignFonts.caption(size: 11)
+        countLabel.textColor = DesignColors.textDisabled
+        countLabel.alignment = .right
+        countLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(countLabel)
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
+
+            topLine.topAnchor.constraint(equalTo: containerView.topAnchor),
+            topLine.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topLine.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topLine.heightAnchor.constraint(equalToConstant: 1),
+
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            titleLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -2),
+
+            countLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            countLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+        ])
+    }
+
+    /// Configure with both counts. The header sits above the unregistered
+    /// section and labels the transition from registered → unregistered.
+    func configure(registeredCount: Int, unregisteredCount: Int) {
+        let unitReg = unregisteredCount == 1 ? "character" : "characters"
+        titleLabel.stringValue = "Available — not in select.def"
+        countLabel.stringValue = "\(unregisteredCount) \(unitReg) (\(registeredCount) in roster above)"
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.stringValue = "Available"
+        countLabel.stringValue = ""
     }
 }

--- a/IKEMEN Lab/UI/CharacterBrowserView.swift
+++ b/IKEMEN Lab/UI/CharacterBrowserView.swift
@@ -342,14 +342,13 @@ NotificationCenter.default.publisher(for: .customTagsChanged)
         switch registrationFilter {
         case .all:
             // Group registered (active/disabled) before unregistered while
-            // preserving relative ordering inside each group. The section
-            // header in section 1 visually labels the unregistered group.
-            characters = allCharacters.sorted { lhs, rhs in
-                let lUnreg = (lhs.status == .unregistered)
-                let rUnreg = (rhs.status == .unregistered)
-                if lUnreg == rUnreg { return false }  // stable within group
-                return !lUnreg  // registered first
-            }
+            // preserving relative ordering inside each group. `Array.sorted`
+            // is not guaranteed stable in Swift; using two filters keeps
+            // input order intact within each group, which matters because
+            // select.def ordering is significant.
+            let registered = allCharacters.filter { $0.status != .unregistered }
+            let unregistered = allCharacters.filter { $0.status == .unregistered }
+            characters = registered + unregistered
         case .registeredOnly:
             characters = allCharacters.filter { $0.status == .active || $0.status == .disabled }
         case .unregisteredOnly:
@@ -1260,6 +1259,13 @@ extension CharacterBrowserView: NSCollectionViewDelegate {
                 destinationIndex = activeScreenpackSlotLimit + indexPath.item
             }
         } else if let split = unregisteredSectionStartIndex() {
+            // Reject drops that would cross the registered/unregistered split:
+            // moving a registered character into the unregistered group (or
+            // vice versa) would break the partition invariant the divider
+            // depends on, and unregistered items don't belong in select.def.
+            let sourceWasRegistered = sourceIndex < split
+            let dropTargetIsRegistered = (indexPath.section == 0)
+            guard sourceWasRegistered == dropTargetIsRegistered else { return false }
             if indexPath.section == 0 {
                 destinationIndex = indexPath.item
             } else {

--- a/IKEMEN Lab/UI/CollectionEditorView.swift
+++ b/IKEMEN Lab/UI/CollectionEditorView.swift
@@ -1713,45 +1713,56 @@ class StageEntryItem: NSCollectionViewItem {
     
     func configure(with folder: String) {
         self.stageFolder = folder
-        
+
         // Normalize the folder string - remove .def extension if present
         let normalizedFolder = folder.lowercased().hasSuffix(".def")
             ? String(folder.dropLast(4))
             : folder
-        
-        // Look up stage info for display name
+        let needle = normalizedFolder.lowercased()
+
+        // Look up stage info, trying several keys because stored folder strings
+        // can be the DEF id (loose stages), the parent folder name (subfolder
+        // stages), or even the raw .def filename. Match against stage.id,
+        // stage.name, and the .def filename minus extension so all variants
+        // resolve to the same StageInfo.
         let stageInfo = IkemenBridge.shared.stages.first(where: { stage in
-            stage.id.lowercased() == normalizedFolder.lowercased()
+            if stage.id.lowercased() == needle { return true }
+            if stage.name.lowercased() == needle { return true }
+            let defBase = stage.defFile.deletingPathExtension().lastPathComponent.lowercased()
+            if defBase == needle { return true }
+            return false
         })
-        
+
         nameLabel.stringValue = stageInfo?.name ?? normalizedFolder
-        
+
         // Reset to placeholder state
         thumbnailView.image = nil
         thumbnailView.contentTintColor = nil
         placeholderStack.isHidden = true
-        
+
         // Try to load thumbnail
         loadThumbnail(for: normalizedFolder, stageInfo: stageInfo)
     }
     
     private func loadThumbnail(for folder: String, stageInfo: StageInfo?) {
-        // Check cache first
-        let cacheKey = ImageCache.stagePreviewKey(for: folder)
+        // Prefer the resolved stage's id for cache parity with StageBrowserView
+        // (which keys previews by stage.id). Fall back to the folder string when
+        // we couldn't resolve a stage so the call still has a stable key.
+        let cacheKey = ImageCache.stagePreviewKey(for: stageInfo?.id ?? folder)
         if let cached = ImageCache.shared.get(cacheKey) {
             showThumbnail(cached)
             return
         }
-        
+
         // Load asynchronously
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             var image: NSImage? = nil
-            
+
             // Try SFF extraction first (most common source)
             if let stage = stageInfo {
                 image = stage.loadPreviewImage()
             }
-            
+
             // Update UI on main thread
             DispatchQueue.main.async { [weak self] in
                 if let finalImage = image {

--- a/IKEMEN Lab/UI/CollectionEditorView.swift
+++ b/IKEMEN Lab/UI/CollectionEditorView.swift
@@ -1456,20 +1456,30 @@ class RosterEntryItem: NSCollectionViewItem {
         
         switch entry.entryType {
         case .character:
-            // Look up character info for display name
-            var displayName = entry.characterFolder ?? "Unknown"
-            if let folder = entry.characterFolder,
-               let character = IkemenBridge.shared.characters.first(where: { $0.directory.lastPathComponent == folder }) {
-                displayName = character.displayName
+            // Resolve a display label by preferring the parsed DEF display name,
+            // falling back to the parsed name, then to the raw folder string.
+            let folder = entry.characterFolder
+            let character = folder.flatMap { f in
+                IkemenBridge.shared.characters.first(where: { $0.directory.lastPathComponent == f })
+            }
+            let trimmedDisplay = character?.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedName = character?.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayName: String
+            if let d = trimmedDisplay, !d.isEmpty {
+                displayName = d
+            } else if let n = trimmedName, !n.isEmpty {
+                displayName = n
+            } else {
+                displayName = folder ?? "Unknown"
             }
             nameLabel.stringValue = displayName
             nameLabel.textColor = DesignColors.textSecondary
             thumbnailView.image = NSImage(systemSymbolName: "person.fill", accessibilityDescription: nil)
             thumbnailView.contentTintColor = DesignColors.textSecondary
-            
+
             // Load actual thumbnail
-            if let folder = entry.characterFolder {
-                loadThumbnail(for: folder)
+            if let resolvedFolder = folder {
+                loadThumbnail(for: resolvedFolder)
             }
             
         case .randomSelect:

--- a/plan.md
+++ b/plan.md
@@ -27,10 +27,10 @@
 ## Current Focus
 
 ### 🐛 Known Bugs (Backlog)
-- [ ] **Smart Collections: Tag matching inconsistent** — Some characters with detected tags not matching in smart collection rules
-- [ ] **Collections: Character names incorrect** — Showing folder names instead of display names from DEF files
-- [ ] **Collections: Stage thumbnails not loading** — Some stages showing placeholder icon
-- [ ] **Characters: "UNREGISTERED" badge UX** — Replace with "In Roster" / "Available" section dividers
+- [x] **Smart Collections: Tag matching inconsistent** — Resolved in v1.0.0 (consistent end-to-end normalization)
+- [x] **Collections: Character names incorrect** — Resolved in v1.0.0 (prefer DEF display names with name/folder fallback)
+- [x] **Collections: Stage thumbnails not loading** — Resolved in v1.0.0 (multi-key stage lookup + shared cache)
+- [x] **Characters: "UNREGISTERED" badge UX** — Resolved in v1.0.0 (replaced with section divider; cutoff divider takes priority)
 - [x] **Window header not draggable** — Custom header doesn't behave like standard macOS title bar
 
 ### 📋 Up Next (Post-1.0)
@@ -95,6 +95,11 @@ All alpha tasks complete!
 | ├─ Developer ID Application signing (Release builds) | ✅ Done |
 | ├─ Hardened Runtime enabled | ✅ Done |
 | └─ Notarized DMG build script | ✅ Done |
+| **Bug Fixes** | ✅ Done |
+| ├─ Smart Collection tag matching normalized end-to-end | ✅ Done |
+| ├─ Collection roster shows DEF display names (not folders) | ✅ Done |
+| ├─ Collection stage thumbnails resolve via id/name/defFile | ✅ Done |
+| └─ Replace UNREGISTERED badge with section divider | ✅ Done |
 
 ### 🧩 v1.1 — Polish & Fixes
 | Feature | Status |
@@ -105,7 +110,6 @@ All alpha tasks complete!
 | Existing installation import | 📋 Todo |
 | Drag & Drop to Collections | 📋 Todo |
 | Bulk Add to Collection | 📋 Todo |
-| Smart Collections tag matching fix | 📋 Todo |
 
 ### ⚡ v2 — Smart Features
 | Feature | Status |


### PR DESCRIPTION
Resolves the four bugs listed under "Known Bugs" in plan.md.

## Summary

- **Smart Collections tag matching** (`SmartCollectionEvaluator.swift`) — normalize tags consistently (trim + lowercase + Set dedup) so case/whitespace differences between detected tags and rule values no longer cause silent misses.
- **Collection roster shows folder names** (`CollectionEditorView.swift` ~line 1454-1483) — resolve the character via `IkemenBridge.shared.characters` and prefer `displayName` (parsed from DEF), falling back to `name`, then to the folder string.
- **Stage thumbnails missing in collections** (`CollectionEditorView.swift` ~line 1714-1764) — stage lookup now matches by `id`, `name`, and `defFile.lastPathComponent` (minus extension) so DEF-filename vs folder-name mismatches don't drop the thumbnail.
- **UNREGISTERED badge → section divider** (`CharacterBrowserView.swift`) — replaced the per-card red overlay with a single "Available" section header; cards are sorted registered-first, with a soft 0.6 alpha dim on the unregistered group as a secondary cue.

## Caveats

- **Bug 4 compromise:** the cutoff (slot-limit) divider and the new registered/unregistered divider are mutually exclusive — when a screenpack slot limit is exceeded, the cutoff divider takes priority. Mixing both in one `NSCollectionViewFlowLayout` would have required a much larger data-source/drag-drop refactor. Cards are still sorted registered-first in both modes.
- The legacy `unregisteredOverlay` / `unregisteredBadge` views are left in place but always hidden, to keep `prepareForReuse` semantics intact. Worth deleting in a follow-up.
- All changes verified by inspection only — Linux worktree without Xcode. Build + visual smoke test recommended before merge, especially:
  - The new `RegistrationDividerView` rendering in the section-header slot
  - Drag-and-drop reorder still updating `select.def` correctly within the registered group

## Test plan

- [ ] Builds in Xcode without warnings
- [ ] Smart Collection rule matching `Tag = "HD"` matches characters with detected tag `HD`, `hd`, ` HD `
- [ ] Open a collection — character cards show DEF display names, not folder slugs
- [ ] Open a collection — stage thumbnails render for all stages that previously showed placeholders
- [ ] Character browser shows "Available" section header before unregistered characters; no red badges
- [ ] Drag-reorder within the registered group still persists to `select.def`
- [ ] Cutoff (slot-limit) divider still appears when a screenpack limit is exceeded

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfES5vuG9aHgHHWaLP8W2k)_