### PR TITLE
Gate debug prints behind #if DEBUG and document release build flow

### DIFF
--- a/IKEMEN Lab/Core/FullgameImporter.swift
+++ b/IKEMEN Lab/Core/FullgameImporter.swift
@@ -1,6 +1,15 @@
 import Foundation
 import AppKit
 
+// MARK: - Debug Logging
+
+/// File-scoped debug logger; compiled out of release builds.
+private func dlog(_ msg: @autoclosure () -> String) {
+    #if DEBUG
+    print(msg())
+    #endif
+}
+
 // MARK: - Fullgame Import Types
 
 /// Result of scanning a folder for fullgame content
@@ -119,14 +128,14 @@ final class FullgameImporter {
     func scanFullgamePackage(at url: URL) -> FullgameManifest {
         var manifest = FullgameManifest(sourceURL: url, sourceFolderName: url.lastPathComponent)
         
-        print("[FullgameImporter] Scanning: \(url.path)")
+        dlog("[FullgameImporter] Scanning: \(url.path)")
         
         // Scan for characters (chars/ subfolder)
         let charsDir = url.appendingPathComponent("chars")
-        print("[FullgameImporter] Checking chars at: \(charsDir.path), exists: \(fileManager.fileExists(atPath: charsDir.path))")
+        dlog("[FullgameImporter] Checking chars at: \(charsDir.path), exists: \(fileManager.fileExists(atPath: charsDir.path))")
         if fileManager.fileExists(atPath: charsDir.path) {
             manifest.characters = scanCharactersFolder(charsDir)
-            print("[FullgameImporter] Found \(manifest.characters.count) characters: \(manifest.characters.map { $0.folderName })")
+            dlog("[FullgameImporter] Found \(manifest.characters.count) characters: \(manifest.characters.map { $0.folderName })")
         }
         
         // Scan for stages (stages/ subfolder)
@@ -290,12 +299,12 @@ final class FullgameImporter {
         var result = FullgameImportResult()
         var currentAction: DuplicateAction = .ask
         
-        print("[FullgameImporter] Starting installation to: \(workingDir.path)")
-        print("[FullgameImporter] Found \(manifest.characters.count) characters, \(manifest.stages.count) stages")
+        dlog("[FullgameImporter] Starting installation to: \(workingDir.path)")
+        dlog("[FullgameImporter] Found \(manifest.characters.count) characters, \(manifest.stages.count) stages")
         
         // 1. Install characters
         for character in manifest.characters {
-            print("[FullgameImporter] Installing character: \(character.folderName)")
+            dlog("[FullgameImporter] Installing character: \(character.folderName)")
             do {
                 let installed = try installCharacterWithDuplicateHandling(
                     character: character,
@@ -304,18 +313,18 @@ final class FullgameImporter {
                     duplicateHandler: duplicateHandler
                 )
                 if let name = installed {
-                    print("[FullgameImporter] Character installed as: \(name)")
+                    dlog("[FullgameImporter] Character installed as: \(name)")
                     result.charactersInstalled.append(name)
                 } else {
-                    print("[FullgameImporter] Character skipped")
+                    dlog("[FullgameImporter] Character skipped")
                 }
             } catch {
-                print("[FullgameImporter] Character failed: \(error.localizedDescription)")
+                dlog("[FullgameImporter] Character failed: \(error.localizedDescription)")
                 result.charactersFailed.append((character.folderName, error.localizedDescription))
             }
         }
         
-        print("[FullgameImporter] Characters installed: \(result.charactersInstalled)")
+        dlog("[FullgameImporter] Characters installed: \(result.charactersInstalled)")
         
         // Reset action for stages
         if currentAction != .overwriteAll && currentAction != .skipAll {
@@ -324,7 +333,7 @@ final class FullgameImporter {
         
         // 2. Install stages
         for stage in manifest.stages {
-            print("[FullgameImporter] Installing stage: \(stage.name), isLoose: \(stage.isLooseFile)")
+            dlog("[FullgameImporter] Installing stage: \(stage.name), isLoose: \(stage.isLooseFile)")
             do {
                 let installed = try installStageWithDuplicateHandling(
                     stage: stage,
@@ -334,53 +343,53 @@ final class FullgameImporter {
                     duplicateHandler: duplicateHandler
                 )
                 if let name = installed {
-                    print("[FullgameImporter] Stage installed as: \(name)")
+                    dlog("[FullgameImporter] Stage installed as: \(name)")
                     result.stagesInstalled.append(name)
                 } else {
-                    print("[FullgameImporter] Stage skipped")
+                    dlog("[FullgameImporter] Stage skipped")
                 }
             } catch {
-                print("[FullgameImporter] Stage failed: \(error.localizedDescription)")
+                dlog("[FullgameImporter] Stage failed: \(error.localizedDescription)")
                 result.stagesFailed.append((stage.name, error.localizedDescription))
             }
         }
         
-        print("[FullgameImporter] Stages installed: \(result.stagesInstalled)")
+        dlog("[FullgameImporter] Stages installed: \(result.stagesInstalled)")
         
         // 3. Install screenpack
         if let screenpack = manifest.screenpack {
             do {
                 // Use folder name based on manifest name for consistency
                 let screenpackFolderName = CollectionNameResolver.sanitizeForFolder(manifest.suggestedCollectionName)
-                print("[FullgameImporter] Installing screenpack to: \(screenpackFolderName)")
+                dlog("[FullgameImporter] Installing screenpack to: \(screenpackFolderName)")
                 let _ = try installScreenpack(from: screenpack.url, to: workingDir, folderName: screenpackFolderName)
                 result.screenpackInstalled = screenpack.displayName
-                print("[FullgameImporter] Screenpack installed")
+                dlog("[FullgameImporter] Screenpack installed")
             } catch {
-                print("[FullgameImporter] Screenpack failed: \(error.localizedDescription)")
+                dlog("[FullgameImporter] Screenpack failed: \(error.localizedDescription)")
                 result.screenpackFailed = error.localizedDescription
             }
         }
         
         // 4. Install fonts
         result.fontsInstalled = installFonts(manifest.fonts, to: workingDir)
-        print("[FullgameImporter] Fonts installed: \(result.fontsInstalled.count) - \(result.fontsInstalled)")
+        dlog("[FullgameImporter] Fonts installed: \(result.fontsInstalled.count) - \(result.fontsInstalled)")
         
         // 5. Install sounds
         result.soundsInstalled = installSounds(manifest.sounds, to: workingDir)
-        print("[FullgameImporter] Sounds installed: \(result.soundsInstalled.count) - \(result.soundsInstalled)")
+        dlog("[FullgameImporter] Sounds installed: \(result.soundsInstalled.count) - \(result.soundsInstalled)")
         
         // 6. Create collection
-        print("[FullgameImporter] Total installed: \(result.totalInstalled)")
+        dlog("[FullgameImporter] Total installed: \(result.totalInstalled)")
         if result.totalInstalled > 0 {
-            print("[FullgameImporter] Creating collection with \(result.charactersInstalled.count) chars, \(result.stagesInstalled.count) stages")
+            dlog("[FullgameImporter] Creating collection with \(result.charactersInstalled.count) chars, \(result.stagesInstalled.count) stages")
             let collection = createCollectionFromResult(
                 result: result,
                 name: manifest.suggestedCollectionName,
                 screenpackPath: manifest.screenpack != nil ? "data/\(CollectionNameResolver.sanitizeForFolder(manifest.suggestedCollectionName))" : nil
             )
             result.collectionCreated = collection
-            print("[FullgameImporter] Collection created: \(collection.name)")
+            dlog("[FullgameImporter] Collection created: \(collection.name)")
         }
         
         return result
@@ -474,15 +483,15 @@ final class FullgameImporter {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let stageFolder = tempDir.appendingPathComponent(stage.name)
         
-        print("[FullgameImporter] Restructuring loose stage: \(stage.name)")
-        print("[FullgameImporter] Source stages dir: \(stagesDir.path)")
+        dlog("[FullgameImporter] Restructuring loose stage: \(stage.name)")
+        dlog("[FullgameImporter] Source stages dir: \(stagesDir.path)")
         
         try fileManager.createDirectory(at: stageFolder, withIntermediateDirectories: true)
         
         // Copy the .def file
         let defFile = stage.url
         try fileManager.copyItem(at: defFile, to: stageFolder.appendingPathComponent(defFile.lastPathComponent))
-        print("[FullgameImporter] Copied .def file: \(defFile.lastPathComponent)")
+        dlog("[FullgameImporter] Copied .def file: \(defFile.lastPathComponent)")
         
         // Get all files in stages directory for case-insensitive matching
         let allStageFiles = (try? fileManager.contentsOfDirectory(at: stagesDir, includingPropertiesForKeys: nil)) ?? []
@@ -512,7 +521,7 @@ final class FullgameImporter {
                             continue
                         }
                         
-                        print("[FullgameImporter] DEF references SFF: '\(filename)'")
+                        dlog("[FullgameImporter] DEF references SFF: '\(filename)'")
                         
                         // Case-insensitive search for the file
                         let filenameLower = filename.lowercased()
@@ -520,10 +529,10 @@ final class FullgameImporter {
                             let destPath = stageFolder.appendingPathComponent(matchingFile.lastPathComponent)
                             if !fileManager.fileExists(atPath: destPath.path) {
                                 try fileManager.copyItem(at: matchingFile, to: destPath)
-                                print("[FullgameImporter] Copied SFF: \(matchingFile.lastPathComponent)")
+                                dlog("[FullgameImporter] Copied SFF: \(matchingFile.lastPathComponent)")
                             }
                         } else {
-                            print("[FullgameImporter] WARNING: SFF not found: \(filename)")
+                            dlog("[FullgameImporter] WARNING: SFF not found: \(filename)")
                         }
                     }
                 }
@@ -538,7 +547,7 @@ final class FullgameImporter {
                 let destPath = stageFolder.appendingPathComponent(file.lastPathComponent)
                 if !fileManager.fileExists(atPath: destPath.path) {
                     try? fileManager.copyItem(at: file, to: destPath)
-                    print("[FullgameImporter] Copied matching SFF: \(file.lastPathComponent)")
+                    dlog("[FullgameImporter] Copied matching SFF: \(file.lastPathComponent)")
                 }
             }
         }

--- a/IKEMEN Lab/Models/StageInfo.swift
+++ b/IKEMEN Lab/Models/StageInfo.swift
@@ -129,12 +129,16 @@ public struct StageInfo: Identifiable, Hashable {
                     self.sffFile = match
                 } else {
                     self.sffFile = nil
+                    #if DEBUG
                     print("[StageInfo] WARNING: SFF not found (case-insensitive): \(targetURL.path)")
+                    #endif
                 }
             }
         } else {
             self.sffFile = nil
+            #if DEBUG
             print("[StageInfo] WARNING: No spriteFile for \(defFile.lastPathComponent)")
+            #endif
         }
     }
 }

--- a/IKEMEN Lab/UI/DashboardView.swift
+++ b/IKEMEN Lab/UI/DashboardView.swift
@@ -392,7 +392,9 @@ class DashboardView: NSView {
         
         // Add click callback to entire card
         card.onClick = { [weak self] in
+            #if DEBUG
             print("[DashboardView] Launch card onClick triggered")
+            #endif
             self?.launchButtonClicked()
         }
         
@@ -638,7 +640,9 @@ class DashboardView: NSView {
             recentInstalls = try MetadataStore.shared.recentlyInstalled(limit: 10)
             updateRecentlyInstalledUI()
         } catch {
+            #if DEBUG
             print("Failed to load recent installs: \(error)")
+            #endif
         }
     }
     

--- a/IKEMEN Lab/Views/MetalView.swift
+++ b/IKEMEN Lab/Views/MetalView.swift
@@ -2,14 +2,17 @@ import Cocoa
 import Metal
 import MetalKit
 import QuartzCore
+import os.log
 
 /// Metal-backed view for rendering
 /// Currently minimal - Ikemen GO handles its own rendering
 /// Kept for future potential use (character previews, etc.)
 class MetalView: NSView {
-    
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.ikemenlab", category: "MetalView")
+
     // MARK: - Metal Objects
-    
+
     private var device: MTLDevice!
     private var commandQueue: MTLCommandQueue!
     private var metalLayer: CAMetalLayer!
@@ -41,14 +44,14 @@ class MetalView: NSView {
     private func setupMetal() {
         // Get default Metal device
         guard let device = MTLCreateSystemDefaultDevice() else {
-            print("Metal is not supported on this device")
+            Self.logger.error("Metal is not supported on this device")
             return
         }
         self.device = device
-        
+
         // Create command queue
         guard let commandQueue = device.makeCommandQueue() else {
-            print("Failed to create Metal command queue")
+            Self.logger.error("Failed to create Metal command queue")
             return
         }
         self.commandQueue = commandQueue

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ You can help us decide! Add your request in Issues or Discussions.
 
 ## 🛠️ Building from Source
 
+Requires Xcode 15+ and macOS 12.0+.
+
+### Development Build
+
 ```bash
 # Clone the repo
 git clone https://github.com/yourname/ikemen-lab.git
@@ -110,7 +114,37 @@ open "IKEMEN Lab.xcodeproj"
 # Build and run (⌘R)
 ```
 
-Requires Xcode 15+ and macOS 12.0+.
+### Release Builds
+
+`scripts/build-release.sh` produces a signed and notarized DMG for distribution.
+
+**Prerequisites:**
+
+- A "Developer ID Application" certificate installed in your login keychain
+- Your Apple Developer **Team ID**
+- An **app-specific password** for notarization, stored as a notarytool keychain profile:
+  ```bash
+  xcrun notarytool store-credentials "<NOTARY_PROFILE>" \
+      --apple-id "<your-apple-id>" --team-id "<TEAM_ID>"
+  ```
+
+**Configure and run:**
+
+```bash
+# Copy the env template and fill in TEAM_ID + NOTARY_PROFILE
+cp .env.example .env
+$EDITOR .env
+
+# Build, sign, notarize, and package into a DMG
+./scripts/build-release.sh
+
+# Skip notarization for local testing
+SKIP_NOTARIZE=1 ./scripts/build-release.sh
+```
+
+The output DMG lands at the repo root (e.g. `IKEMEN Lab-v1.0.0.dmg`).
+
+> **Note:** The release version string is currently hardcoded in `scripts/build-release.sh` (`VERSION="v1.0.0"`). Bump it there when cutting a new release.
 
 ---
 


### PR DESCRIPTION
Hygiene pass on noisy release-build logging plus a README update for the release flow.

## Summary

- **`FullgameImporter.swift`** — added a file-scoped `dlog(_ msg: @autoclosure () -> String)` helper that no-ops in release; replaced 31 `print()` call sites with `dlog(...)`. Auto-closure means the message string isn't built unless DEBUG.
- **`StageInfo.swift`** — 2 prints inline-gated with `#if DEBUG`.
- **`DashboardView.swift`** — 2 prints inline-gated with `#if DEBUG`.
- **`MetalView.swift`** — 2 prints upgraded to `os_log .error` via `Logger(subsystem:category:)` matching the pattern already used in `SelectDefManager`, `FolderSanitizer`, `ContentInstaller`. These fire only when `MTLCreateSystemDefaultDevice()` or `makeCommandQueue()` returns nil — real diagnostic signal users on broken hardware would benefit from in Console.app, so kept in release.
- **`README.md`** — "Building from Source" rewritten with separate Dev and Release subsections. Release docs `.env` setup, required Apple Developer ID Application certificate / Team ID / app-specific password, and `scripts/build-release.sh`.

**Total prints gated:** 35 (31 via `dlog`, 4 inline `#if DEBUG`). Plus 2 upgraded to `os_log`.

## Test plan

- [ ] Release build is quieter in Console.app — no `[FullgameImporter]` chatter on import
- [ ] Debug build still logs full importer trace
- [ ] MetalView errors still surface in Console.app on hardware without Metal
- [ ] README "Release Builds" section accurately matches `scripts/build-release.sh` and `.env.example`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfES5vuG9aHgHHWaLP8W2k)_