### PR TITLE
Add .claude/ to gitignore for Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ Thumbs.db
 *~
 .vscode/
 
+# Claude Code agent worktrees / scratch
+.claude/
+
 # Test artifacts
 *.xcresult/
 coverage/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `.claude/` directory, which is used by Claude Code agent for worktrees and scratch files.

## Changes
- Added `.claude/` directory to `.gitignore` to prevent accidental commits of Claude Code agent temporary files and worktrees

## Details
This change ensures that local Claude Code agent artifacts are not tracked in version control, keeping the repository clean and avoiding unnecessary commits of temporary development files.

https://claude.ai/code/session_01FfES5vuG9aHgHHWaLP8W2k